### PR TITLE
Roles Unit Tests + Role and User changes

### DIFF
--- a/src/main/java/ro/unibuc/hello/controllers/RoleController.java
+++ b/src/main/java/ro/unibuc/hello/controllers/RoleController.java
@@ -20,10 +20,10 @@ public class RoleController {
         return roleService.getRoles();
     }
 
-    @GetMapping("/roles/{id}")
+    @GetMapping("/roles/{name}")
     @ResponseBody
-    public RoleDTO getRoleById(@PathVariable String id) {
-        return roleService.getRoleById(id);
+    public RoleDTO getRoleByName(@PathVariable String name) {
+        return roleService.getRoleById(name);
     }
 
     @PostMapping("/roles")
@@ -32,15 +32,15 @@ public class RoleController {
         return roleService.addRole(role);
     }
 
-    @PutMapping("/roles/{id}")
+    @PutMapping("/roles/{name}")
     @ResponseBody
-    public RoleDTO updateRole(@PathVariable String id, @RequestBody RoleCreateRequest role) {
-        return roleService.updateRole(id, role);
+    public RoleDTO updateRole(@PathVariable String name, @RequestBody RoleCreateRequest role) {
+        return roleService.updateRole(name, role);
     }
 
-    @DeleteMapping("/roles/{id}")
+    @DeleteMapping("/roles/{name}")
     @ResponseBody
-    public void deleteRole(@PathVariable String id) {
-        roleService.deleteRole(id);
+    public void deleteRole(@PathVariable String name) {
+        roleService.deleteRole(name);
     }
 }

--- a/src/main/java/ro/unibuc/hello/controllers/RoleController.java
+++ b/src/main/java/ro/unibuc/hello/controllers/RoleController.java
@@ -23,7 +23,7 @@ public class RoleController {
     @GetMapping("/roles/{name}")
     @ResponseBody
     public RoleDTO getRoleByName(@PathVariable String name) {
-        return roleService.getRoleById(name);
+        return roleService.getRoleByName(name);
     }
 
     @PostMapping("/roles")

--- a/src/main/java/ro/unibuc/hello/controllers/contracts/RoleCreateRequest.java
+++ b/src/main/java/ro/unibuc/hello/controllers/contracts/RoleCreateRequest.java
@@ -10,6 +10,6 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 public class RoleCreateRequest {
-    private String id;
+    private String name;
     private List<String> policies;
 }

--- a/src/main/java/ro/unibuc/hello/dtos/RoleDTO.java
+++ b/src/main/java/ro/unibuc/hello/dtos/RoleDTO.java
@@ -12,10 +12,10 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @Builder
 public class RoleDTO {
-    private String id;
+    private String name;
     private List<PolicyDTO> policies;
 
     public Role toRole() {
-        return new Role(id, policies.stream().map(PolicyDTO::toPolicy).collect(Collectors.toList()));
+        return new Role(name, policies.stream().map(PolicyDTO::toPolicy).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/ro/unibuc/hello/entities/Role.java
+++ b/src/main/java/ro/unibuc/hello/entities/Role.java
@@ -14,15 +14,15 @@ import java.util.stream.Collectors;
 @Builder
 public class Role {
     @Id
-    private String id;
+    private String name;
     private List<Policy> policies;
 
     @Override
     public String toString() {
-        return String.format("Role[id=%s]", id);
+        return String.format("Role[id=%s]", name);
     }
 
     public RoleDTO toDTO() {
-        return new RoleDTO(id, policies.stream().map(Policy::toDTO).collect(Collectors.toList()));
+        return new RoleDTO(name, policies.stream().map(Policy::toDTO).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/ro/unibuc/hello/repositories/RoleRepository.java
+++ b/src/main/java/ro/unibuc/hello/repositories/RoleRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface RoleRepository extends MongoRepository<Role, String> {
-    Optional<Role> findById(String id);
+    Optional<Role> findByName(String name);
 }

--- a/src/main/java/ro/unibuc/hello/services/RoleService.java
+++ b/src/main/java/ro/unibuc/hello/services/RoleService.java
@@ -27,14 +27,14 @@ public class RoleService {
         return roles.stream().map(Role::toDTO).collect(Collectors.toList());
     }
 
-    public RoleDTO getRoleById(String id){
-        return roleRepository.findById(id).orElseThrow(
+    public RoleDTO getRoleByName(String name){
+        return roleRepository.findByName(name).orElseThrow(
                 () -> new EntityNotFoundException("Role")
         ).toDTO();
     }
 
     public RoleDTO addRole(RoleCreateRequest roleCreateRequest) {
-        var existingRole = roleRepository.findById(roleCreateRequest.getName());
+        var existingRole = roleRepository.findByName(roleCreateRequest.getName());
         if (existingRole.isPresent()) {
             throw new EntityAlreadyExistsException("Role");
         }
@@ -48,8 +48,8 @@ public class RoleService {
         return role.toDTO();
     }
 
-    public RoleDTO updateRole(String id, RoleCreateRequest roleCreateRequest) {
-        var existingRole = roleRepository.findById(id);
+    public RoleDTO updateRole(String name, RoleCreateRequest roleCreateRequest) {
+        var existingRole = roleRepository.findByName(name);
         if (existingRole.isEmpty()) {
             throw new EntityNotFoundException("Role");
         }
@@ -58,7 +58,7 @@ public class RoleService {
             var policy = policyService.getPolicyById(policyId);
             policies.add(policy.toPolicy());
         });
-        var role = roleRepository.findById(id).orElseThrow(
+        var role = roleRepository.findByName(name).orElseThrow(
                 () -> new EntityNotFoundException("Role")
         );
         role.setPolicies(policies);
@@ -66,8 +66,8 @@ public class RoleService {
         return role.toDTO();
     }
 
-    public void deleteRole(String id) {
-        var role = roleRepository.findById(id).orElseThrow(
+    public void deleteRole(String name) {
+        var role = roleRepository.findByName(name).orElseThrow(
                 () -> new EntityNotFoundException("Role")
         );
         roleRepository.delete(role);

--- a/src/main/java/ro/unibuc/hello/services/RoleService.java
+++ b/src/main/java/ro/unibuc/hello/services/RoleService.java
@@ -34,7 +34,7 @@ public class RoleService {
     }
 
     public RoleDTO addRole(RoleCreateRequest roleCreateRequest) {
-        var existingRole = roleRepository.findById(roleCreateRequest.getId());
+        var existingRole = roleRepository.findById(roleCreateRequest.getName());
         if (existingRole.isPresent()) {
             throw new EntityAlreadyExistsException("Role");
         }
@@ -43,7 +43,7 @@ public class RoleService {
             var policy = policyService.getPolicyById(policyId);
             policies.add(policy.toPolicy());
         });
-        var role = new Role(roleCreateRequest.getId(), policies);
+        var role = new Role(roleCreateRequest.getName(), policies);
         roleRepository.save(role);
         return role.toDTO();
     }

--- a/src/main/java/ro/unibuc/hello/services/UserService.java
+++ b/src/main/java/ro/unibuc/hello/services/UserService.java
@@ -54,10 +54,16 @@ public class UserService {
     }
 
     public UserDTO updateUser(String id, UserCreateRequest userCreateRequest) {
-        var existingUser = userRepository.findById(id);
-        if (existingUser.isEmpty()) {
-            throw new EntityNotFoundException("User");
+        // Check if the new id we want to update is already taken by another user different from the one we want to update.
+        var existingUser = userRepository.findById(userCreateRequest.getId());
+        if (existingUser.isPresent() && !existingUser.get().getId().equals(id)) {
+            throw new EntityAlreadyExistsException("User");
         }
+
+        var user = userRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException("User")
+        );
+
         List<Policy> policies = new ArrayList<>();
         List<Role> roles = new ArrayList<>();
 
@@ -70,12 +76,9 @@ public class UserService {
             roles.add(role.toRole());
         });
 
-        var user = userRepository.findById(id).orElseThrow(
-                () -> new EntityNotFoundException("User")
-        );
-
         user.setPolicies(policies);
         user.setRoles(roles);
+        user.setId(userCreateRequest.getId());
         userRepository.save(user);
         return user.toDTO();
     }

--- a/src/main/java/ro/unibuc/hello/services/UserService.java
+++ b/src/main/java/ro/unibuc/hello/services/UserService.java
@@ -44,7 +44,7 @@ public class UserService {
             policies.add(policy.toPolicy());
         });
         userCreateRequest.getRoles().forEach(roleId -> {
-            var role = roleService.getRoleById(roleId);
+            var role = roleService.getRoleByName(roleId);
             roles.add(role.toRole());
         });
 
@@ -66,7 +66,7 @@ public class UserService {
             policies.add(policy.toPolicy());
         });
         userCreateRequest.getRoles().forEach(roleId -> {
-            var role = roleService.getRoleById(roleId);
+            var role = roleService.getRoleByName(roleId);
             roles.add(role.toRole());
         });
 

--- a/src/test/java/ro/unibuc/hello/controllers/RoleControllerTest.java
+++ b/src/test/java/ro/unibuc/hello/controllers/RoleControllerTest.java
@@ -1,0 +1,85 @@
+package ro.unibuc.hello.controllers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import ro.unibuc.hello.controllers.contracts.RoleCreateRequest;
+import ro.unibuc.hello.dtos.RoleDTO;
+import ro.unibuc.hello.services.RoleService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class RoleControllerTest {
+
+    @Mock
+    private RoleService roleService;
+
+    @InjectMocks
+    private RoleController roleController;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testCreateRole() {
+        RoleDTO roleDTO = new RoleDTO("admin", new ArrayList<>());
+        RoleCreateRequest roleCreateRequest = new RoleCreateRequest("admin", new ArrayList<>());
+
+        when(roleService.addRole(roleCreateRequest)).thenReturn(roleDTO);
+
+        RoleDTO result = roleController.addRole(roleCreateRequest);
+
+        assertEquals(roleDTO, result);
+        verify(roleService, times(1)).addRole(roleCreateRequest);
+    }
+
+    @Test
+    void testGetRoles() {
+        when(roleService.getRoles()).thenReturn(new ArrayList<>());
+
+        List<RoleDTO> result = roleController.getRoles();
+
+        assertEquals(0, result.size());
+        verify(roleService, times(1)).getRoles();
+    }
+
+    @Test
+    void testGetRoleByName() {
+        RoleDTO roleDTO = new RoleDTO("admin", new ArrayList<>());
+
+        when(roleService.getRoleById("admin")).thenReturn(roleDTO);
+
+        RoleDTO result = roleController.getRoleByName("admin");
+
+        assertEquals(roleDTO, result);
+        verify(roleService, times(1)).getRoleById("admin");
+    }
+
+    @Test
+    void testUpdateRole() {
+        RoleDTO roleDTO = new RoleDTO("admin", new ArrayList<>());
+        RoleCreateRequest roleCreateRequest = new RoleCreateRequest("admin", new ArrayList<>());
+
+        when(roleService.updateRole("admin", roleCreateRequest)).thenReturn(roleDTO);
+
+        RoleDTO result = roleController.updateRole("admin", roleCreateRequest);
+
+        assertEquals(roleDTO, result);
+        verify(roleService, times(1)).updateRole("admin", roleCreateRequest);
+    }
+
+    @Test
+    void testDeleteRole() {
+        roleController.deleteRole("admin");
+
+        verify(roleService, times(1)).deleteRole("admin");
+    }
+}

--- a/src/test/java/ro/unibuc/hello/controllers/RoleControllerTest.java
+++ b/src/test/java/ro/unibuc/hello/controllers/RoleControllerTest.java
@@ -29,7 +29,7 @@ class RoleControllerTest {
     }
 
     @Test
-    void testCreateRole() {
+    void test_createRole() {
         RoleDTO roleDTO = new RoleDTO("admin", new ArrayList<>());
         RoleCreateRequest roleCreateRequest = new RoleCreateRequest("admin", new ArrayList<>());
 
@@ -42,7 +42,7 @@ class RoleControllerTest {
     }
 
     @Test
-    void testGetRoles() {
+    void test_getRoles() {
         when(roleService.getRoles()).thenReturn(new ArrayList<>());
 
         List<RoleDTO> result = roleController.getRoles();
@@ -52,19 +52,19 @@ class RoleControllerTest {
     }
 
     @Test
-    void testGetRoleByName() {
+    void test_getRoleByName() {
         RoleDTO roleDTO = new RoleDTO("admin", new ArrayList<>());
 
-        when(roleService.getRoleById("admin")).thenReturn(roleDTO);
+        when(roleService.getRoleByName("admin")).thenReturn(roleDTO);
 
         RoleDTO result = roleController.getRoleByName("admin");
 
         assertEquals(roleDTO, result);
-        verify(roleService, times(1)).getRoleById("admin");
+        verify(roleService, times(1)).getRoleByName("admin");
     }
 
     @Test
-    void testUpdateRole() {
+    void test_updateRole() {
         RoleDTO roleDTO = new RoleDTO("admin", new ArrayList<>());
         RoleCreateRequest roleCreateRequest = new RoleCreateRequest("admin", new ArrayList<>());
 
@@ -77,7 +77,7 @@ class RoleControllerTest {
     }
 
     @Test
-    void testDeleteRole() {
+    void test_deleteRole() {
         roleController.deleteRole("admin");
 
         verify(roleService, times(1)).deleteRole("admin");

--- a/src/test/java/ro/unibuc/hello/services/RoleServiceTest.java
+++ b/src/test/java/ro/unibuc/hello/services/RoleServiceTest.java
@@ -1,0 +1,160 @@
+package ro.unibuc.hello.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import ro.unibuc.hello.controllers.contracts.RoleCreateRequest;
+import ro.unibuc.hello.dtos.PolicyDTO;
+import ro.unibuc.hello.entities.Role;
+import ro.unibuc.hello.repositories.RoleRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class RoleServiceTest {
+
+    @Mock
+    RoleRepository roleRepository;
+
+    @Mock
+    PolicyService policyService;
+
+    @InjectMocks
+    RoleService roleService = new RoleService();
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void test_getRoles() {
+        List<Role> roles = new ArrayList<>();
+        roles.add(new Role("role1", new ArrayList<>()));
+        roles.add(new Role("role2", new ArrayList<>()));
+
+        when(roleRepository.findAll()).thenReturn(roles);
+
+        var result = roleService.getRoles();
+
+        assertEquals(2, result.size());
+        assertEquals("role1", result.get(0).getName());
+        assertEquals("role2", result.get(1).getName());
+        verify(roleRepository, times(1)).findAll();
+    }
+
+    @Test
+    void test_getByName_returnsRoleDTO() {
+        Role role = new Role("role1", new ArrayList<>());
+        when(roleRepository.findByName("role1")).thenReturn(Optional.of(role));
+
+        var result = roleService.getRoleByName("role1");
+
+        assertEquals("role1", result.getName());
+        verify(roleRepository, times(1)).findByName("role1");
+    }
+
+    @Test
+    void test_getByName_throwsEntityNotFoundException() {
+        when(roleRepository.findByName("role1")).thenReturn(Optional.empty());
+
+        try {
+            roleService.getRoleByName("role1");
+        } catch (Exception e) {
+            assertEquals("Entity: Role was not found", e.getMessage());
+        }
+        verify(roleRepository, times(1)).findByName("role1");
+    }
+
+    @Test
+    void test_addRole_returnsRoleDTO() {
+        RoleCreateRequest roleCreateRequest = new RoleCreateRequest("role1", List.of("1", "2"));
+
+        when(roleRepository.findByName("role1")).thenReturn(Optional.empty());
+        when(policyService.getPolicyById("1")).thenReturn(new PolicyDTO("1", "policy1", new ArrayList<>()));
+        when(policyService.getPolicyById("2")).thenReturn(new PolicyDTO("2", "policy2", new ArrayList<>()));
+
+        var result = roleService.addRole(roleCreateRequest);
+
+        assertEquals("role1", result.getName());
+        verify(roleRepository, times(1)).findByName("role1");
+        verify(policyService, times(1)).getPolicyById("1");
+        verify(policyService, times(1)).getPolicyById("2");
+        verify(roleRepository, times(1)).save(any());
+    }
+
+    @Test
+    void test_addRole_throwsEntityAlreadyExistsException() {
+        RoleCreateRequest roleCreateRequest = new RoleCreateRequest("role1", List.of("1", "2"));
+
+        when(roleRepository.findByName("role1")).thenReturn(Optional.of(new Role("role1", new ArrayList<>())));
+
+        try {
+            roleService.addRole(roleCreateRequest);
+        } catch (Exception e) {
+            assertEquals("Entity: Role already exists", e.getMessage());
+        }
+        verify(roleRepository, times(1)).findByName("role1");
+    }
+
+    @Test
+    void test_updateRole_returnsRoleDTO() {
+        RoleCreateRequest roleCreateRequest = new RoleCreateRequest("role1", List.of("1", "2"));
+        Role role = new Role("role1", new ArrayList<>());
+
+        when(roleRepository.findByName("role1")).thenReturn(Optional.of(role));
+        when(policyService.getPolicyById("1")).thenReturn(new PolicyDTO("1", "policy1", new ArrayList<>()));
+        when(policyService.getPolicyById("2")).thenReturn(new PolicyDTO("2", "policy2", new ArrayList<>()));
+
+        var result = roleService.updateRole("role1", roleCreateRequest);
+
+        assertEquals("role1", result.getName());
+        verify(roleRepository, times(2)).findByName("role1");
+        verify(policyService, times(1)).getPolicyById("1");
+        verify(policyService, times(1)).getPolicyById("2");
+        verify(roleRepository, times(1)).save(any());
+    }
+
+    @Test
+    void test_updateRole_throwsEntityNotFoundException() {
+        RoleCreateRequest roleCreateRequest = new RoleCreateRequest("role1", List.of("1", "2"));
+
+        when(roleRepository.findByName("role1")).thenReturn(Optional.empty());
+
+        try {
+            roleService.updateRole("role1", roleCreateRequest);
+        } catch (Exception e) {
+            assertEquals("Entity: Role was not found", e.getMessage());
+        }
+        verify(roleRepository, times(1)).findByName("role1");
+    }
+
+    @Test
+    void test_deleteRole() {
+        Role role = new Role("role1", new ArrayList<>());
+        when(roleRepository.findByName("role1")).thenReturn(Optional.of(role));
+
+        roleService.deleteRole("role1");
+
+        verify(roleRepository, times(1)).findByName("role1");
+        verify(roleRepository, times(1)).delete(role);
+    }
+
+    @Test
+    void test_deleteRole_throwsEntityNotFoundException() {
+        when(roleRepository.findByName("role1")).thenReturn(Optional.empty());
+
+        try {
+            roleService.deleteRole("role1");
+        } catch (Exception e) {
+            assertEquals("Entity: Role was not found", e.getMessage());
+        }
+        verify(roleRepository, times(1)).findByName("role1");
+    }
+}

--- a/src/test/java/ro/unibuc/hello/services/RoleServiceTest.java
+++ b/src/test/java/ro/unibuc/hello/services/RoleServiceTest.java
@@ -123,16 +123,38 @@ public class RoleServiceTest {
 
     @Test
     void test_updateRole_throwsEntityNotFoundException() {
-        RoleCreateRequest roleCreateRequest = new RoleCreateRequest("role1", List.of("1", "2"));
+        RoleCreateRequest roleCreateRequest = new RoleCreateRequest("newRoleName", List.of("1", "2"));
 
-        when(roleRepository.findByName("role1")).thenReturn(Optional.empty());
+        when(roleRepository.findByName("newRoleName")).thenReturn(Optional.empty());
+        when(roleRepository.findByName("currentRoleName")).thenReturn(Optional.empty());
 
         try {
-            roleService.updateRole("role1", roleCreateRequest);
+            roleService.updateRole("currentRoleName", roleCreateRequest);
         } catch (Exception e) {
             assertEquals("Entity: Role was not found", e.getMessage());
         }
-        verify(roleRepository, times(1)).findByName("role1");
+        verify(roleRepository, times(1)).findByName("newRoleName");
+        verify(roleRepository, times(1)).findByName("currentRoleName");
+        verify(roleRepository, times(0)).save(any());
+    }
+
+    @Test
+    void test_updateRole_throwsEntityAlreadyExistsException() {
+        RoleCreateRequest roleCreateRequest = new RoleCreateRequest("newRoleName", List.of("1", "2"));
+        Role existingRole = new Role("newRoleName", new ArrayList<>());
+        Role roleToUpdate = new Role("currentRoleName", new ArrayList<>());
+
+        when(roleRepository.findByName("newRoleName")).thenReturn(Optional.of(existingRole));
+        when(roleRepository.findByName("currentRoleName")).thenReturn(Optional.of(roleToUpdate));
+
+        try {
+            roleService.updateRole("currentRoleName", roleCreateRequest);
+        } catch (Exception e) {
+            assertEquals("Entity: Role already exists", e.getMessage());
+        }
+        verify(roleRepository, times(1)).findByName("newRoleName");
+        verify(roleRepository, times(0)).findByName("currentRoleName");
+        verify(roleRepository, times(0)).save(any());
     }
 
     @Test


### PR DESCRIPTION
- Added unit tests for RoleService and RoleController to 100% coverage.
- Role id is now called name.
- UserService throws EntityAlreadyExists when trying to change a user's id to an id that another user already has.
- RoleService throws EntityAlreadyExists when trying to change a role's name to a name that another role already has.